### PR TITLE
Fix surprise api change

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 // Manifest version information!
 def versionMajor = 1
 def versionMinor = 2
-def versionPatch = 1
+def versionPatch = 2
 def versionBuild = 0 // bump for dogfood builds, public betas, etc.
 
 android {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,7 +41,15 @@
             </intent-filter>
         </receiver>
 
+        <receiver android:name=".receiver.MyPackageReplacedReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+            </intent-filter>
+        </receiver>
+
         <service android:name=".service.LessonReminderService"/>
+
+        <service android:name=".service.ReplaceSyncIdService"/>
 
         <meta-data
             android:name="io.fabric.ApiKey"

--- a/app/src/main/java/by/toggi/rxbsuir/PreferenceHelper.java
+++ b/app/src/main/java/by/toggi/rxbsuir/PreferenceHelper.java
@@ -14,6 +14,7 @@ public class PreferenceHelper {
     public static final String NOTIFICATION_TIME = "notification_time";
     public static final String NOTIFICATION_SOUND_ENABLED = "notification_sound_enabled";
     public static final String IS_TODAY_ENABLED = "is_today_enabled";
+    public static final String IS_SURPRISE_API_FIX_APPLIED = "is_surprise_api_fix_applied";
 
     private PreferenceHelper() {
     }

--- a/app/src/main/java/by/toggi/rxbsuir/activity/ScheduleActivity.java
+++ b/app/src/main/java/by/toggi/rxbsuir/activity/ScheduleActivity.java
@@ -394,7 +394,7 @@ public abstract class ScheduleActivity extends AppCompatActivity implements Sche
 
     private void selectGroupOrEmployee(int id, String s, boolean isGroupSchedule) {
         mItemIdPreference.set(id);
-        mSyncIdPreference.set(isGroupSchedule ? s : String.valueOf(id));
+        mSyncIdPreference.set(String.valueOf(id));
         mIsGroupSchedulePreference.set(isGroupSchedule);
         mSchedulePresenter.setSyncId(mSyncIdPreference.get(), mIsGroupSchedulePreference.get());
         mTitlePreference.set(s);

--- a/app/src/main/java/by/toggi/rxbsuir/component/AppComponent.java
+++ b/app/src/main/java/by/toggi/rxbsuir/component/AppComponent.java
@@ -21,6 +21,7 @@ import by.toggi.rxbsuir.module.BsuirServiceModule;
 import by.toggi.rxbsuir.module.DbModule;
 import by.toggi.rxbsuir.module.PreferencesModule;
 import by.toggi.rxbsuir.service.LessonReminderService;
+import by.toggi.rxbsuir.service.ReplaceSyncIdService;
 import dagger.Component;
 
 @Singleton
@@ -57,5 +58,7 @@ public interface AppComponent {
     void inject(TodayFragment todayFragment);
 
     void inject(WeekScheduleActivity weekScheduleActivity);
+
+    void inject(ReplaceSyncIdService replaceSyncIdService);
 
 }

--- a/app/src/main/java/by/toggi/rxbsuir/db/RxBsuirOpenHelper.java
+++ b/app/src/main/java/by/toggi/rxbsuir/db/RxBsuirOpenHelper.java
@@ -11,7 +11,7 @@ import static by.toggi.rxbsuir.db.RxBsuirContract.StudentGroupEntry;
 public class RxBsuirOpenHelper extends SQLiteOpenHelper {
 
     private static final String DATABASE_NAME = "rxbsuir.db";
-    private static final int DATABASE_VERSION = 2;
+    private static final int DATABASE_VERSION = 3;
 
     public RxBsuirOpenHelper(Context context) {
         super(context, DATABASE_NAME, null, DATABASE_VERSION);
@@ -69,5 +69,26 @@ public class RxBsuirOpenHelper extends SQLiteOpenHelper {
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        int upgradeTo = oldVersion + 1;
+        while (upgradeTo <= newVersion) {
+            switch (upgradeTo) {
+                case 3:
+                    db.execSQL(getSwitchSyncIdQuery());
+                    break;
+            }
+            upgradeTo++;
+        }
+    }
+
+    private static String getSwitchSyncIdQuery() {
+        return "update " +
+                LessonEntry.TABLE_NAME + " set " +
+                LessonEntry.COL_SYNC_ID + " = ifnull((select " +
+                StudentGroupEntry.COL_ID + " from " +
+                StudentGroupEntry.TABLE_NAME + " where " +
+                LessonEntry.TABLE_NAME + "." + LessonEntry.COL_SYNC_ID + " = " +
+                StudentGroupEntry.COL_NAME + "), " +
+                LessonEntry.TABLE_NAME + "." + LessonEntry.COL_SYNC_ID + ") where " +
+                LessonEntry.COL_IS_GROUP_SCHEDULE + " = 1";
     }
 }

--- a/app/src/main/java/by/toggi/rxbsuir/mvp/presenter/SchedulePresenter.java
+++ b/app/src/main/java/by/toggi/rxbsuir/mvp/presenter/SchedulePresenter.java
@@ -178,7 +178,7 @@ public class SchedulePresenter extends Presenter<ScheduleView> {
                 .listOfObjects(StudentGroup.class)
                 .withQuery(Query.builder()
                         .table(StudentGroupEntry.TABLE_NAME)
-                        .where(StudentGroupEntry.COL_NAME + " = ?")
+                        .where(StudentGroupEntry.COL_ID + " = ?")
                         .whereArgs(mSyncId)
                         .build())
                 .prepare()

--- a/app/src/main/java/by/toggi/rxbsuir/receiver/MyPackageReplacedReceiver.java
+++ b/app/src/main/java/by/toggi/rxbsuir/receiver/MyPackageReplacedReceiver.java
@@ -1,0 +1,22 @@
+package by.toggi.rxbsuir.receiver;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import by.toggi.rxbsuir.BuildConfig;
+import by.toggi.rxbsuir.service.ReplaceSyncIdService;
+
+public class MyPackageReplacedReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        switch (BuildConfig.VERSION_CODE) {
+            // Surprise API change
+            case 12200:
+                context.startService(new Intent(context, ReplaceSyncIdService.class));
+                break;
+        }
+    }
+
+}

--- a/app/src/main/java/by/toggi/rxbsuir/receiver/MyPackageReplacedReceiver.java
+++ b/app/src/main/java/by/toggi/rxbsuir/receiver/MyPackageReplacedReceiver.java
@@ -4,19 +4,13 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
-import by.toggi.rxbsuir.BuildConfig;
 import by.toggi.rxbsuir.service.ReplaceSyncIdService;
 
 public class MyPackageReplacedReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        switch (BuildConfig.VERSION_CODE) {
-            // Surprise API change
-            case 12200:
-                context.startService(new Intent(context, ReplaceSyncIdService.class));
-                break;
-        }
+        context.startService(new Intent(context, ReplaceSyncIdService.class));
     }
 
 }

--- a/app/src/main/java/by/toggi/rxbsuir/receiver/MyPackageReplacedReceiver.java
+++ b/app/src/main/java/by/toggi/rxbsuir/receiver/MyPackageReplacedReceiver.java
@@ -3,14 +3,20 @@ package by.toggi.rxbsuir.receiver;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.preference.PreferenceManager;
 
+import by.toggi.rxbsuir.PreferenceHelper;
 import by.toggi.rxbsuir.service.ReplaceSyncIdService;
 
 public class MyPackageReplacedReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        context.startService(new Intent(context, ReplaceSyncIdService.class));
+        boolean isFixApplied = PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(PreferenceHelper.IS_SURPRISE_API_FIX_APPLIED, false);
+        if (!isFixApplied) {
+            context.startService(new Intent(context, ReplaceSyncIdService.class));
+        }
     }
 
 }

--- a/app/src/main/java/by/toggi/rxbsuir/service/ReplaceSyncIdService.java
+++ b/app/src/main/java/by/toggi/rxbsuir/service/ReplaceSyncIdService.java
@@ -1,0 +1,64 @@
+package by.toggi.rxbsuir.service;
+
+import android.app.IntentService;
+import android.content.Intent;
+
+import com.f2prateek.rx.preferences.Preference;
+import com.pushtorefresh.storio.sqlite.StorIOSQLite;
+import com.pushtorefresh.storio.sqlite.queries.Query;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import by.toggi.rxbsuir.PreferenceHelper;
+import by.toggi.rxbsuir.RxBsuirApplication;
+import by.toggi.rxbsuir.rest.model.StudentGroup;
+
+import static by.toggi.rxbsuir.db.RxBsuirContract.StudentGroupEntry;
+
+/**
+ * This IntentService runs by the system upon package update to switch values of sync id.
+ * This is due unexpected API change, where bsuir.by now uses id for endpoints, rather than name
+ */
+public class ReplaceSyncIdService extends IntentService {
+
+    @Inject @Named(PreferenceHelper.FAVORITE_SYNC_ID) Preference<String> mFavoriteSyncIdPreference;
+    @Inject @Named(PreferenceHelper.FAVORITE_IS_GROUP_SCHEDULE) Preference<Boolean> mFavoriteIsGroupSchedulePreference;
+    @Inject @Named(PreferenceHelper.SYNC_ID) Preference<String> mSyncIdPreference;
+    @Inject @Named(PreferenceHelper.IS_GROUP_SCHEDULE) Preference<Boolean> mIsGroupSchedulePreference;
+    @Inject StorIOSQLite mStorIOSQLite;
+
+    public ReplaceSyncIdService() {
+        super(ReplaceSyncIdService.class.getSimpleName());
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        ((RxBsuirApplication) getApplication()).getAppComponent().inject(this);
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        changeSyncId(mSyncIdPreference, mIsGroupSchedulePreference);
+        changeSyncId(mFavoriteSyncIdPreference, mFavoriteIsGroupSchedulePreference);
+    }
+
+    private void changeSyncId(Preference<String> syncIdPreference, Preference<Boolean> isGroupSchedulePreference) {
+        Boolean b = isGroupSchedulePreference.get();
+        if (b != null && b) {
+            List<StudentGroup> groups = mStorIOSQLite.get()
+                    .listOfObjects(StudentGroup.class)
+                    .withQuery(Query.builder()
+                            .table(StudentGroupEntry.TABLE_NAME)
+                            .where(StudentGroupEntry.COL_NAME + " = ?")
+                            .whereArgs(syncIdPreference.get())
+                            .build()).prepare().executeAsBlocking();
+            if (groups.size() == 1) {
+                syncIdPreference.set(String.valueOf(groups.get(0).id));
+            }
+        }
+    }
+}

--- a/app/src/main/java/by/toggi/rxbsuir/service/ReplaceSyncIdService.java
+++ b/app/src/main/java/by/toggi/rxbsuir/service/ReplaceSyncIdService.java
@@ -2,6 +2,7 @@ package by.toggi.rxbsuir.service;
 
 import android.app.IntentService;
 import android.content.Intent;
+import android.preference.PreferenceManager;
 
 import com.f2prateek.rx.preferences.Preference;
 import com.pushtorefresh.storio.sqlite.StorIOSQLite;
@@ -44,6 +45,10 @@ public class ReplaceSyncIdService extends IntentService {
     protected void onHandleIntent(Intent intent) {
         changeSyncId(mSyncIdPreference, mIsGroupSchedulePreference);
         changeSyncId(mFavoriteSyncIdPreference, mFavoriteIsGroupSchedulePreference);
+        PreferenceManager.getDefaultSharedPreferences(getApplicationContext())
+                .edit()
+                .putBoolean(PreferenceHelper.IS_SURPRISE_API_FIX_APPLIED, true)
+                .apply();
     }
 
     private void changeSyncId(Preference<String> syncIdPreference, Preference<Boolean> isGroupSchedulePreference) {


### PR DESCRIPTION
BSUIR API changed unexpectedly (likely to facilitate master groups (5M****)) which broke schedule downloading (always empty schedule for groups, fine for employees). This pull request should update db entries with new sync_id as ids for groups (rather than their names) and update currently selected sync_id and favorite_sync_id.
